### PR TITLE
Added a zero approve before _amount approve in L78

### DIFF
--- a/contracts/v3/converters/StablesConverter.sol
+++ b/contracts/v3/converters/StablesConverter.sol
@@ -75,6 +75,7 @@ contract StablesConverter is IConverter {
         external
         onlyStrategist
     {
+        _token.safeApprove(_spender, 0);
         _token.safeApprove(_spender, _amount);
     }
 


### PR DESCRIPTION
This will prevent SafeApprove from reverting in case current approval is not 0.