### PR TITLE
Used _balance in L367

### DIFF
--- a/contracts/v3/controllers/Controller.sol
+++ b/contracts/v3/controllers/Controller.sol
@@ -364,7 +364,7 @@ contract Controller is IController {
         }
         uint256 _balance = _vaultDetails[_vault].balance;
         if (_balance >= _amount) {
-            _vaultDetails[_vault].balance = _vaultDetails[_vault].balance.sub(_amount);
+            _vaultDetails[_vault].balance = _balance.sub(_amount);
         } else {
             _vaultDetails[_vault].balance = 0;
         }


### PR DESCRIPTION
Replaced _vaultDetails[_vault].balance with the already fetched value _balance in L367.
Issue: https://github.com/code-423n4/2021-09-yaxis-findings/issues/65