### PR TITLE
Removed notHalted in L217

### DIFF
--- a/contracts/v3/Vault.sol
+++ b/contracts/v3/Vault.sol
@@ -214,7 +214,6 @@ contract Vault is VaultToken, IVault {
     )
         external
         override
-        notHalted
         returns (uint256 _shares)
     {
         require(_tokens.length == _amounts.length, "!length");


### PR DESCRIPTION
notHalted is already checked in deposit(), which is called by depositMulitple().
Issue: https://github.com/code-423n4/2021-09-yaxis-findings/issues/70