### PR TITLE
setMinter validates _minter isn't empty L43

### DIFF
--- a/contracts/v3/MinterWrapper.sol
+++ b/contracts/v3/MinterWrapper.sol
@@ -40,6 +40,7 @@ contract MinterWrapper is Ownable {
         onlyOwner
     {
         require(minter == address(0), "minter");
+        require(_minter != address(0), "!_minter");
         minter = _minter;
     }
 


### PR DESCRIPTION
added require(_minter != address(0), "!_minter"); at L43.
Issue: https://github.com/code-423n4/2021-09-yaxis-findings/issues/81