### PR TITLE
Support change of USDC decimals

### DIFF
--- a/contracts/v3/strategies/NativeStrategyCurve3Crv.sol
+++ b/contracts/v3/strategies/NativeStrategyCurve3Crv.sol
@@ -87,7 +87,7 @@ contract NativeStrategyCurve3Crv is BaseStrategy {
     {
         uint256[] memory balances = new uint256[](3);
         balances[0] = stableSwap3Pool.balances(0); // DAI
-        balances[1] = stableSwap3Pool.balances(1).mul(10**12); // USDC
+        balances[1] = stableSwap3Pool.balances(1).mul(10**18).div(10**(IERC20(usdc).decimals())); // USDC - Supports a change up to the 18 decimal standard
         balances[2] = stableSwap3Pool.balances(2).mul(10**12); // USDT
 
         if (balances[0] < balances[1] && balances[0] < balances[2]) { // DAI


### PR DESCRIPTION
L90: Support the change of USDC decimals since it uses a proxy contract, up to the 18 decimal standard.
Issue: https://github.com/code-423n4/2021-09-yaxis-findings/issues/82