### PR TITLE
Fixed Withdraw event in withdraw function

### DIFF
--- a/contracts/v3/controllers/LegacyController.sol
+++ b/contracts/v3/controllers/LegacyController.sol
@@ -155,6 +155,7 @@ contract LegacyController is ILegacyController {
         // happy path exits without calling back to the vault
         if (_balance >= _amount) {
             token.safeTransfer(metavault, _amount);
+            emit Withdraw(_amount);
         } else {
             uint256 _toWithdraw = _amount.sub(_balance);
             // convert to vault shares
@@ -168,9 +169,9 @@ contract LegacyController is ILegacyController {
             IERC20(_tokens[0]).safeTransfer(address(converter), _balance);
             // TODO: calculate expected
             converter.convert(_tokens[0], address(token), _balance, 1);
+            emit Withdraw(token.balanceOf(address(this)));
             token.safeTransfer(metavault, token.balanceOf(address(this)));
         }
-        emit Withdraw(_amount);
     }
 
     /**


### PR DESCRIPTION
The Withdraw event in LegacyController.withdraw emits the _amount variable which is the initial, desired amount to withdraw. It will now emit the actual withdrawn amount instead, which is transferred in the last token.balanceOf(address(this)) call.