### PR TITLE
Removed unused parameter and modifier

### DIFF
--- a/contracts/v3/controllers/LegacyController.sol
+++ b/contracts/v3/controllers/LegacyController.sol
@@ -128,12 +128,10 @@ contract LegacyController is ILegacyController {
      * @param _amount The amount to withdraw
      */
     function withdrawFee(
-        address _token,
         uint256 _amount
     )
         external
         view
-        onlyToken(_token)
         returns (uint256)
     {
         return manager.withdrawalProtectionFee().mul(_amount).div(MAX);


### PR DESCRIPTION
withdrawalProtectionFe() appears to be the same for all tokens and therefore the parameter _token and the onlyToken() modifier are unused. Removing it and the modifier can save gas.
Issue: https://github.com/code-423n4/2021-09-yaxis-findings/issues/58