### PR TITLE
Vault: L309 Normalized decimals in the second part

### DIFF
--- a/contracts/v3/Vault.sol
+++ b/contracts/v3/Vault.sol
@@ -306,7 +306,7 @@ contract Vault is VaultToken, IVault {
         override
         returns (uint256 _balance)
     {
-        return balanceOfThis().add(IController(manager.controllers(address(this))).balanceOf());
+        return balanceOfThis().add(_normalizeDecimals(IController(manager.controllers(address(this))).balanceOf()));
     }
 
     /**


### PR DESCRIPTION
Should now report the correct balance instead of underreporting in cases of <18 decimal tokens.